### PR TITLE
Editor-relative positioning

### DIFF
--- a/doc/fidget.md
+++ b/doc/fidget.md
@@ -82,6 +82,11 @@ The following table shows the default options for this plugin:
     fidget_decay = 2000,      -- how long to keep around empty fidget, in ms
     task_decay = 1000,        -- how long to keep around completed task, in ms
   },
+  window = {
+    relative = "win",         -- where to anchor the window, either `"win"` or `"editor"`
+    blend = 100,              -- `&winblend` for the window
+    zindex = nil,             -- the `zindex` value for the window
+  },
   fmt = {
     leftpad = true,           -- right-justify text in fidget box
     stack_upwards = true,     -- list of tasks grows upwards
@@ -145,6 +150,25 @@ Whether to align fidgets along the right edge of each buffer. Setting this to
 regularly overlaid on top of buffer text (which is supported but unsightly).
 
 Type: `bool` (default: `true`)
+
+#### window.relative
+
+Whether to position the window relative to the current window, or the editor.
+Valid values are `"win"` or `"editor"`.
+
+Type: `string` (default: `"win"`)
+
+#### window.winblend
+
+The value to use for `&winblend` for the window.
+
+Type: `number` (default: `100`)
+
+#### window.zindex
+
+The value to use for `zindex` (see `:h nvim_win_open`) for the window.
+
+Type: `number` (default: `nil`)
 
 #### timer.spinner_rate
 


### PR DESCRIPTION
Allow positioning relative to the editor, closes #13

Also:

- Customizable `zindex`
- Customizable `winblend`
- Check if window/buffer valid before closing them (comes into play with something like forced wipeouts from the user)
- Use `next(...)` for checking if items exist in a map-like table

---

With editor-relative positioning, it isn't super easy to know things like the width of the `&signcolumn`/`&foldcolumn` for the left-most window, so that is not handled. Otherwise, things like `&cmdheight`, tabline, statusline, etc. should all be handled.