### PR TITLE
If value.kind is nil, kill the process

### DIFF
--- a/lua/fidget.lua
+++ b/lua/fidget.lua
@@ -319,7 +319,7 @@ local function handle_progress(err, msg, info)
     if val.message then
       progress.message = val.message
     end
-  elseif val.kind == "end" then
+  elseif val.kind == "end" or val.kind == nil then
     if progress.percentage then
       progress.percentage = 100
     end

--- a/lua/fidget.lua
+++ b/lua/fidget.lua
@@ -319,7 +319,7 @@ local function handle_progress(err, msg, info)
     if val.message then
       progress.message = val.message
     end
-  elseif val.kind == "end" or val.kind == nil then
+  elseif val.kind == "end" then
     if progress.percentage then
       progress.percentage = 100
     end
@@ -331,6 +331,9 @@ local function handle_progress(err, msg, info)
     elseif options.timer.task_decay == 0 then
       fidget:kill_task(task)
     end
+  else
+    log.warn("Invalid progress notification received:", msg)
+    fidget:kill_task(task)
   end
 
   fidget:fmt()


### PR DESCRIPTION
If the format of LSP's progress endpoint is different, the process will not end.
For example, angularls looks like this.

```
[DEBUG Sun 30 Jan 2022 07:52:03 PM JST] ...e/dein/repos/github.com/j-hui/fidget.nvim/lua/fidget.lua:284: Received progress notification: {
  info = {
    client_id = 1,
    method = "$/progress"
  },
  msg = {
    token = "ngcc",
    value = {
      configFilePath = "/home/aikawa/d/workspace/nyujihogo/shirayuri/tsconfig.json",
      done = false,
      message = "Running ngcc for /home/aikawa/d/workspace/nyujihogo/shirayuri/tsconfig.json"
    }
  }
}
```

And the notification remains on the screen
![screenshot (1)](https://user-images.githubusercontent.com/42488829/151698182-df5270f1-ac5f-4000-a2ea-208b672f2bb1.jpg)
