### PR TITLE
Fix a bug where tasks were shared across different fidgets

### DIFF
--- a/lua/fidget.lua
+++ b/lua/fidget.lua
@@ -263,7 +263,7 @@ end
 local function new_fidget(key, name)
   local fidget = vim.tbl_extend(
     "force",
-    base_fidget,
+    vim.deepcopy(base_fidget),
     { key = key, name = name }
   )
   if options.timer.spinner_rate > 0 then


### PR DESCRIPTION
This fixes the bug reported in #10 where LSP tasks were being shared
with different fidgets. This bug is because of the shared object
`base_fidget.tasks`, which instead should be deep-copied.

Fix #10.
