### PR TITLE
Allow configuration to ignore sources

### DIFF
--- a/doc/fidget.md
+++ b/doc/fidget.md
@@ -104,10 +104,14 @@ The following table shows the default options for this plugin:
         )
       end,
   },
+  sources = {                 -- Sources to configure
+    * = {                     -- Name of source
+      ignore = false,         -- Ignore notifications from this source
+    },
+  },
   debug = {
     logging = false,          -- whether to enable logging, for debugging
   },
-  ignored = {}                -- A table of LSP client names to ignore, such as null-ls.
 }
 ```
 
@@ -224,18 +228,24 @@ the formatted task status.
 
 Type: `(string, string, string) -> string` (default: something sane)
 
+#### sources.SOURCE_NAME
+
+Options for fidget source with name `SOURCE_NAME`.
+
+Type: `{options}` (default: see individual per-source options)
+
+#### sources.SOURCE_NAME.ignore
+
+Disable fidgets from `SOURCE_NAME`.
+
+Type: `bool` (default: `false`)
+
 #### debug.logging
 
 Whether to enable logging, for debugging. The log is written to
 `~/.local/share/fidget.nvim.log`.
 
 Type: `bool` (default: `false`)
-
-#### ignored
-
-Type: `table` (default: `{}`)
-
-A table of LSP client names to ignore when showing status.
 
 ## Highlights
 

--- a/doc/fidget.md
+++ b/doc/fidget.md
@@ -107,6 +107,7 @@ The following table shows the default options for this plugin:
   debug = {
     logging = false,          -- whether to enable logging, for debugging
   },
+  ignored = {}                -- A table of LSP client names to ignore, such as null-ls.
 }
 ```
 
@@ -229,6 +230,12 @@ Whether to enable logging, for debugging. The log is written to
 `~/.local/share/fidget.nvim.log`.
 
 Type: `bool` (default: `false`)
+
+#### ignored
+
+Type: `table` (default: `{}`)
+
+A table of LSP client names to ignore when showing status.
 
 ## Highlights
 

--- a/doc/fidget.txt
+++ b/doc/fidget.txt
@@ -118,6 +118,7 @@ The following table shows the default options for this plugin:
       debug = {
         logging = false,          -- whether to enable logging, for debugging
       },
+      ignored = {}                -- A table of LSP client names to ignore, such as null-ls.
     }
 <
 
@@ -286,6 +287,15 @@ debug.logging                          Whether to enable logging, for
 
 
 Type: `bool` (default: `false`)
+
+
+                                                        *fidget-ignored*
+
+ignored                                A table of LSP client names to ignore,
+                                       such as null-ls.
+
+
+Type: `table` (default: `{}`)
 
 HIGHLIGHTS                                                 *fidget-highlights*
 

--- a/lua/fidget.lua
+++ b/lua/fidget.lua
@@ -38,10 +38,10 @@ local options = {
       )
     end,
   },
+  sources = {},
   debug = {
     logging = false,
   },
-  ignored = {},
 }
 
 local fidgets = {}
@@ -289,16 +289,16 @@ local function handle_progress(err, msg, info)
 
   local task = msg.token
   local val = msg.value
+
+  if not task then
+    -- Notification missing required token??
+    return
+  end
+
   local client_key = info.client_id
   local client_name = vim.lsp.get_client_by_id(info.client_id).name
 
-  for _, ignored in ipairs(options.ignored) do
-    if client_name == ignored then
-      return
-    end
-  end
-
-  if not task then
+  if options.sources[client_name] and options.sources[client_name].ignore then
     return
   end
 

--- a/lua/fidget.lua
+++ b/lua/fidget.lua
@@ -41,6 +41,7 @@ local options = {
   debug = {
     logging = false,
   },
+  ignored = {},
 }
 
 local fidgets = {}
@@ -289,6 +290,13 @@ local function handle_progress(err, msg, info)
   local task = msg.token
   local val = msg.value
   local client_key = info.client_id
+  local client_name = vim.lsp.get_client_by_id(info.client_id).name
+
+  for _, ignored in ipairs(options.ignored) do
+    if client_name == ignored then
+      return
+    end
+  end
 
   if not task then
     return
@@ -296,10 +304,7 @@ local function handle_progress(err, msg, info)
 
   -- Create entry if missing
   if fidgets[client_key] == nil then
-    fidgets[client_key] = new_fidget(
-      client_key,
-      vim.lsp.get_client_by_id(info.client_id).name
-    )
+    fidgets[client_key] = new_fidget(client_key, client_name)
   end
   local fidget = fidgets[client_key]
   if fidget.tasks[task] == nil then


### PR DESCRIPTION
Supercedes #34 (I wasn't able to push to @dsully's branch).

The primary change here is I changed around how each source can be configured. Right now, the only option is to ignore a source, but in the future I want to add the option to silence reporting tasks from each source, which someone suggested to keep the plugin less noisy.

