### PR TITLE
Add FidgetClose command

### DIFF
--- a/doc/fidget.md
+++ b/doc/fidget.md
@@ -258,16 +258,16 @@ Type: `bool` (default: `false`)
 
 ## Commands
 
-#### FidgetKill
+#### FidgetClose
 
 Closes ongoing fidget(s) (i.e., it has incomplete tasks), removing its spinner.
-Arguments can be given to kill specific fidgets, e.g.,:
+Arguments can be given to close specific fidgets, e.g.,:
 
 ```
-:FidgetKill null-ls rust-analyzer
+:FidgetClose null-ls rust-analyzer
 ```
 
-If no arguments are provided, all sources will be killed.
+If no arguments are provided, all sources will be closed.
 
 This command is primarily useful for clearing the UI when tasks appear to
 be unresponsive (see https://github.com/j-hui/fidget.nvim/issues/28).

--- a/doc/fidget.md
+++ b/doc/fidget.md
@@ -256,6 +256,24 @@ Whether to enable logging, for debugging. The log is written to
 
 Type: `bool` (default: `false`)
 
+## Commands
+
+#### FidgetKill
+
+Closes ongoing fidget(s) (i.e., it has incomplete tasks), removing its spinner.
+Arguments can be given to kill specific fidgets, e.g.,:
+
+```
+:FidgetKill null-ls rust-analyzer
+```
+
+If no arguments are provided, all sources will be killed.
+
+This command is primarily useful for clearing the UI when tasks appear to
+be unresponsive (see https://github.com/j-hui/fidget.nvim/issues/28).
+Note that this command does not silence a source: subsequent notifications will
+restart the fidget.
+
 ## Highlights
 
 This plugin uses the following highlights to display the fidgets, and can be

--- a/lua/fidget.lua
+++ b/lua/fidget.lua
@@ -65,7 +65,7 @@ local function get_window_position(offset)
     local laststatus = vim.opt.laststatus:get()
     if
       laststatus == 2
-      or (laststatus == 1 and #vim.api.nvim_tabpage_list_wins() > 1)
+      or (laststatus == 1 and #api.nvim_tabpage_list_wins() > 1)
     then
       statusline_height = 1
     end
@@ -85,7 +85,7 @@ local function get_window_position(offset)
       local showtabline = vim.opt.showtabline:get()
       if
         showtabline == 2
-        or (showtabline == 1 and #vim.api.nvim_list_tabpages() > 1)
+        or (showtabline == 1 and #api.nvim_list_tabpages() > 1)
       then
         baseheight = 1
       end
@@ -109,6 +109,7 @@ local base_fidget = {
   lines = {},
   spinner_idx = 0,
   max_line_len = 0,
+  is_kill = false,
 }
 
 function base_fidget:fmt()
@@ -249,6 +250,10 @@ function base_fidget:spin()
     self:spin()
   end
 
+  if self.is_kill then
+    return
+  end
+
   if self:has_tasks() then
     local next_idx = (self.spinner_idx + 1) % #options.text.spinner
     do_spin(next_idx, spin_again, options.timer.spinner_rate)
@@ -353,6 +358,36 @@ function M.is_installed()
   return vim.lsp.handlers["$/progress"] == handle_progress
 end
 
+function M.get_fidgets()
+  local clients = {}
+  for _, client in ipairs(vim.lsp.get_active_clients()) do
+    table.insert(clients, client.name)
+  end
+  return clients
+end
+
+function M.kill(...)
+  local args = { n = select("#", ...), ... }
+  local function do_kill(client_id)
+    if fidgets[client_id] ~= nil then
+      fidgets[client_id]:close()
+      fidgets[client_id].is_kill = true
+      fidgets[client_id] = nil
+    end
+  end
+
+  if args.n == 0 then
+    for client_id, _ in pairs(fidgets) do
+      do_kill(client_id)
+    end
+    for i = 1, args.n do
+      do_kill(args[i])
+    end
+  end
+
+  render_fidgets()
+end
+
 function M.setup(opts)
   options = vim.tbl_deep_extend("force", options, opts or {})
 
@@ -371,6 +406,13 @@ function M.setup(opts)
   vim.lsp.handlers["$/progress"] = handle_progress
   vim.cmd([[highlight default link FidgetTitle Title]])
   vim.cmd([[highlight default link FidgetTask NonText]])
+
+  vim.cmd([[
+    function FidgetComplete(lead, cmd, cursor)
+      return luaeval('require"fidget".get_fidgets()')
+    endfunction
+    command -nargs=* -complete=customlist,FidgetComplete FidgetKill lua require'fidget'.kill(<f-args>)
+  ]])
 end
 
 return M

--- a/lua/fidget.lua
+++ b/lua/fidget.lua
@@ -109,7 +109,7 @@ local base_fidget = {
   lines = {},
   spinner_idx = 0,
   max_line_len = 0,
-  is_kill = false,
+  closed = false,
 }
 
 function base_fidget:fmt()
@@ -250,7 +250,7 @@ function base_fidget:spin()
     self:spin()
   end
 
-  if self.is_kill then
+  if self.closed then
     return
   end
 
@@ -366,22 +366,22 @@ function M.get_fidgets()
   return clients
 end
 
-function M.kill(...)
+function M.close(...)
   local args = { n = select("#", ...), ... }
-  local function do_kill(client_id)
+  local function do_close(client_id)
     if fidgets[client_id] ~= nil then
       fidgets[client_id]:close()
-      fidgets[client_id].is_kill = true
+      fidgets[client_id].closed = true
       fidgets[client_id] = nil
     end
   end
 
   if args.n == 0 then
     for client_id, _ in pairs(fidgets) do
-      do_kill(client_id)
+      do_close(client_id)
     end
     for i = 1, args.n do
-      do_kill(args[i])
+      do_close(args[i])
     end
   end
 
@@ -411,7 +411,7 @@ function M.setup(opts)
     function FidgetComplete(lead, cmd, cursor)
       return luaeval('require"fidget".get_fidgets()')
     endfunction
-    command -nargs=* -complete=customlist,FidgetComplete FidgetKill lua require'fidget'.kill(<f-args>)
+    command -nargs=* -complete=customlist,FidgetComplete FidgetClose lua require'fidget'.close(<f-args>)
   ]])
 end
 


### PR DESCRIPTION
Workaround for #28, suggested by @wookayin .

Note that this does not actually disable notifications coming from a source, it just kills the spinner if notifications have ceased. If there are new notifications, the spinner will be started again.

TODO:

- [x] document this command