### PR TITLE
Fix for #29: Defer drawing fidgets to avoid not-allowed-here errors.

### DIFF
--- a/lua/fidget.lua
+++ b/lua/fidget.lua
@@ -364,7 +364,7 @@ local function handle_progress(err, msg, info)
     end
   end
 
-  fidget:fmt()
+  vim.schedule(function() fidget:fmt() end)
 end
 
 function M.is_installed()


### PR DESCRIPTION
Fix for #29. We defer invocation of fidget:fmt() (in which fidget windows are created) until it's safe to call nvim APIs.