### PR TITLE
Format float percentage without decimals

### DIFF
--- a/lua/fidget.lua
+++ b/lua/fidget.lua
@@ -34,7 +34,7 @@ local options = {
       return string.format(
         "%s%s [%s]",
         message,
-        percentage and string.format(" (%s%%)", percentage) or "",
+        percentage and string.format(" (%.0f%%)", percentage) or "",
         task_name
       )
     end,


### PR DESCRIPTION
clangd sends progress floats with absurd precision drawing a lot of attention. Format these without a decimal.

Before

![before](https://user-images.githubusercontent.com/115270/154433077-3e148d45-f33d-4b26-a6c1-c10f8bdd0f2c.png)

After

![after](https://user-images.githubusercontent.com/115270/154433095-90f19ba7-d8e3-4e0b-8f5f-c1cb1091eec3.png)

Tested also with rust-analyzer and it did not show any negative side-effects.