### PR TITLE
Add support for the new global statusline

### DIFF
--- a/lua/fidget.lua
+++ b/lua/fidget.lua
@@ -65,7 +65,7 @@ local function get_window_position(offset)
     local statusline_height = 0
     local laststatus = vim.opt.laststatus:get()
     if
-      laststatus == 2
+      laststatus == 2 or laststatus == 3
       or (laststatus == 1 and #api.nvim_tabpage_list_wins() > 1)
     then
       statusline_height = 1


### PR DESCRIPTION
Fix fidget overlapping with statusline when using the new laststatus option

I guess we should wait for https://github.com/neovim/neovim/pull/17266 to be merged first (?)