### PR TITLE
handle falsy task values

### DIFF
--- a/doc/fidget.md
+++ b/doc/fidget.md
@@ -234,7 +234,7 @@ Type: `(string, string) -> string` (default: something sane)
 
 Function used to format the status of each task. Given three arguments:
 the name of the task, its message, and its progress as a percentage. Returns
-the formatted task status.
+the formatted task status. If this value is false, don't show tasks at all.
 
 Type: `(string, string, string) -> string` (default: something sane)
 

--- a/doc/fidget.txt
+++ b/doc/fidget.txt
@@ -293,7 +293,8 @@ fmt.task                               Function used to format the status of
                                        each task. Given three arguments: the
                                        name of the task, its message, and its
                                        progress as a percentage. Returns the
-                                       formatted task status.
+                                       formatted task status. If this value is
+                                       false, don't show tasks at all.
 
 
 Type: `(string, string, string) -> string` (default: something sane)

--- a/lua/fidget.lua
+++ b/lua/fidget.lua
@@ -128,17 +128,19 @@ function base_fidget:fmt()
   self.lines = { line }
   self.max_line_len = strlen(line)
   for _, task in pairs(self.tasks) do
-    line = options.fmt.task(
+    line = options.fmt.task and options.fmt.task(
       subtab(task.title),
       subtab(task.message),
       task.percentage
     )
-    if options.fmt.stack_upwards then
-      table.insert(self.lines, 1, line)
-    else
-      table.insert(self.lines, line)
+    if line then
+      if options.fmt.stack_upwards then
+        table.insert(self.lines, 1, line)
+      else
+        table.insert(self.lines, line)
+      end
+      self.max_line_len = math.max(self.max_line_len, strlen(line))
     end
-    self.max_line_len = math.max(self.max_line_len, strlen(line))
   end
 
   -- Never try to output any text wider than what we are aligning to.

--- a/lua/fidget.lua
+++ b/lua/fidget.lua
@@ -128,11 +128,12 @@ function base_fidget:fmt()
   self.lines = { line }
   self.max_line_len = strlen(line)
   for _, task in pairs(self.tasks) do
-    line = options.fmt.task and options.fmt.task(
-      subtab(task.title),
-      subtab(task.message),
-      task.percentage
-    )
+    line = options.fmt.task
+      and options.fmt.task(
+        subtab(task.title),
+        subtab(task.message),
+        task.percentage
+      )
     if line then
       if options.fmt.stack_upwards then
         table.insert(self.lines, 1, line)


### PR DESCRIPTION
Hi, thanks for your work on this plugin. I certainly appreciate visual feedback while LSPs are still loading :+1: 

This PR allows returning a falsy value in the task `fmt` function, in which case no task line will be displayed (as opposed to an empty line). This allows ignoring specific tasks if the user isn't interested in them.

It also allows setting the `fmt` to false to never show tasks altogether. This is useful for users who are only interested in the spinner but not the task descriptions at all.