### PR TITLE
add FidgetProgress global to expose progress

### DIFF
--- a/lua/fidget.lua
+++ b/lua/fidget.lua
@@ -2,6 +2,8 @@ local M = {}
 local api = vim.api
 local log = require("fidget.log")
 
+FidgetProgress = {}
+
 local options = {
   text = {
     spinner = "pipe",
@@ -337,6 +339,7 @@ local function handle_progress(err, msg, info)
   end
 
   local progress = fidget.tasks[task]
+  FidgetProgress[client_name] = val.kind
 
   -- Update progress state
   if val.kind == "begin" then


### PR DESCRIPTION
I'd like to be able to configure some other things in my config using the LSP's progress. I'm wondering if you would allow a global which exposes the progress(es) as a table. Perhaps other users will find it helpful as well.

