### PR TITLE
bugfix: check client exists before access

### DIFF
--- a/lua/fidget.lua
+++ b/lua/fidget.lua
@@ -321,7 +321,11 @@ local function handle_progress(err, msg, info)
   end
 
   local client_key = info.client_id
-  local client_name = vim.lsp.get_client_by_id(info.client_id).name
+  local client = vim.lsp.get_client_by_id(info.client_id)
+  if not client then
+    return
+  end
+  local client_name = client.name
 
   if options.sources[client_name] and options.sources[client_name].ignore then
     return


### PR DESCRIPTION
When reloading your `init.lua`, for those brave enough to try and reloading all modules, lspconfig will stop the client and restart it. Some plugins handle this well, others less so. In the case of fidget it seems to always expect the client

https://github.com/j-hui/fidget.nvim/blob/cbe0db4f2adfddfd830310e5846f8735d4e068fa/lua/fidget.lua#L324

This PR fixes this, so it checks first if the client exists before continuing with the function which requires access to this. This doesn't change or break any functionality from my testing, it just prevents fidget exploding when my config is reloaded