### PR TITLE
Handle new neovim global status line support

### DIFF
--- a/lua/fidget.lua
+++ b/lua/fidget.lua
@@ -66,6 +66,7 @@ local function get_window_position(offset)
     local laststatus = vim.opt.laststatus:get()
     if
       laststatus == 2
+      or laststatus == 3
       or (laststatus == 1 and #api.nvim_tabpage_list_wins() > 1)
     then
       statusline_height = 1


### PR DESCRIPTION
Neovim just merged support for global status line which allows to have a single status line for all windows.

Fidget is rendering on top of it instead of above it as it would for non global status line.