### PR TITLE
Call an existing callback if there is one

### DIFF
--- a/lua/fidget.lua
+++ b/lua/fidget.lua
@@ -464,7 +464,16 @@ function M.setup(opts)
     options.text.spinner = spinner
   end
 
-  vim.lsp.handlers["$/progress"] = handle_progress
+  if vim.lsp.handlers["$/progress"] then
+     local old_handler = vim.lsp.handlers["$/progress"]
+     vim.lsp.handlers["$/progress"] = function(...)
+       old_handler(...)
+       handle_progress(...)
+     end
+  else
+     vim.lsp.handlers["$/progress"] = handle_progress
+  end
+
   vim.cmd([[highlight default link FidgetTitle Title]])
   vim.cmd([[highlight default link FidgetTask NonText]])
 


### PR DESCRIPTION
I was looking towards using both fidget, and lualine-lsp-progress, and being able to enable/disable fidget as necessary.
I haven't looked to see if there is enable/disable commands yet, but here is work towards getting both working in the same session...

With this patch you have to load lsp_utils first, and then fidget calls it. since it is that order `is_installed` should continue working.
where lualine-lsp-progress doesn't have anything like `is_installed`.  I don't think this is a particularly ecosystem wide scalable practice.  But I'm not sure it is any worse than clobbering each others callbacks?

If setup in the correct order no changes to lualine-lsp-progress should be needed, should just work.