### PR TITLE
add filetype option to fidget buffer

### DIFF
--- a/lua/fidget.lua
+++ b/lua/fidget.lua
@@ -252,6 +252,7 @@ function base_fidget:show(offset)
 
   if self.bufid == nil or not api.nvim_buf_is_valid(self.bufid) then
     self.bufid = api.nvim_create_buf(false, true)
+    api.nvim_buf_set_option(self.bufid, "filetype", "fidget")
   end
   if self.winid == nil or not api.nvim_win_is_valid(self.winid) then
     self.winid = api.nvim_open_win(self.bufid, false, {


### PR DESCRIPTION
Hi @j-hui!

I have added an filetype to the fidget buffer. This helps identifying the buffer / window in user configs.
This might be helpful for others as well.

This was just a quickfix for myself. Let me know if theres anything that should be added (like documentation, etc.).

Best regards!