### PR TITLE
feat: support window border

### DIFF
--- a/lua/fidget.lua
+++ b/lua/fidget.lua
@@ -38,6 +38,7 @@ local options = {
     relative = "win",
     blend = 100,
     zindex = nil,
+    border = "none",
   },
   timer = {
     spinner_rate = 125,
@@ -266,6 +267,7 @@ function base_fidget:show(offset)
       style = "minimal",
       zindex = options.window.zindex,
       noautocmd = true,
+      border = options.window.border,
     })
   else
     api.nvim_win_set_config(self.winid, {


### PR DESCRIPTION
Add an option to set the window border.

Motivation: The default `blend` is 100 meaning totally transparent and it will be blended with the code under it. To avoid this we may change `blend` to a smaller value. But, the window is still hard to recognize especially when it is above a large piece of code. Adding a border will make fidget window easy to tell and prettier.

Thank you. 