### PR TITLE
Ignore progress notifications on `VimLeavePre` and fix crash on exit

### DIFF
--- a/lua/fidget.lua
+++ b/lua/fidget.lua
@@ -316,7 +316,14 @@ function base_fidget:close()
     self.winid = nil
   end
   if self.bufid ~= nil and api.nvim_buf_is_valid(self.bufid) then
-    api.nvim_buf_delete(self.bufid, { force = true })
+    -- If the fidget buffer becomes the current one after closing the fidget
+    -- window, this most likely means that vim is exiting, although VimLeavePre
+    -- autocmd was not executed yet.
+    -- Deleting the buffer at this point causes a Neovim crash.
+    -- We let the buffer be - it will be deleted automatically on vim exit.
+    if self.bufid ~= api.nvim_get_current_buf() then
+      api.nvim_buf_delete(self.bufid, { force = true })
+    end
     self.bufid = nil
   end
 

--- a/lua/fidget.lua
+++ b/lua/fidget.lua
@@ -385,8 +385,13 @@ local function new_task()
   return { title = nil, message = nil, percentage = nil }
 end
 
+local vim_closing = false
+
 local function handle_progress(err, msg, info)
   -- See: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#progress
+  if vim_closing then
+    return
+  end
 
   log.debug(
     "Received progress notification:",
@@ -522,6 +527,14 @@ function M.setup(opts)
   else
      vim.lsp.handlers["$/progress"] = handle_progress
   end
+
+  vim.api.nvim_create_autocmd("VimLeavePre", {
+    callback = function()
+      log.debug("VimLeavePre")
+      vim_closing = true
+      M.close()
+    end
+  })
 
   vim.cmd([[highlight default link FidgetTitle Title]])
   vim.cmd([[highlight default link FidgetTask NonText]])


### PR DESCRIPTION
Hey!

I grew frustrated of some Neovim crashes that kept happening as I was closing Neovim with modified buffers. After a bunch of debugging I noticed that there were 2 related problems:

1. fidget.nvim kept processing notifications after `VimLeavePre` autocmd fired (which produces annoying but harmless logs in the terminal after existing Neovim, as mentioned in #86 and #110)
2. Calling `nvim_buf_delete` on a fidget buffer when it was the current buffer (which crashed Neovim)
    
    Here is a Neovim backtrace from this situation

    [backtrace.txt](https://github.com/j-hui/fidget.nvim/files/9945897/bt.txt)

    This was particularly annoying because modified buffers were not saved when this happened. Neovim crashed before it got to writing the buffers.

    I tried to come up with better heuristics when calling `nvim_buf_delete` causes this crash. I narrowed it down to `self.bufid == api.nvim_get_current_buf()`. I tried checking the `nvim_list_buf()` and seeing if there are valid and/or loaded buffers, but I didn't find any anomalies there. The only anomaly that causes the crash that I saw how to detect is that fidget buffer becomes the current buffer.

    The crash I saw is the same as in https://github.com/neovim/neovim/issues/20197. For the time being, until the Neovim core issue is fixed, I would rather have this workaround and no crashes.


Since the problems seem related to me, I decided to fix them together, although in 2 separate commits. Take a look at commit messages for more information.

# Crash reproduction

I can reproduce the crash on `main` every time, but I don't know how easy it would be to reproduce for others. Some facts about my setup:

1. I have a `BufWritePre` autocmd that does `vim.lsp.buf.format({ async = false })`
2. I have `prettierd` configured to run via `null-ls` for TypeScript files

Steps to reproduce the crash:

1. `:e file.ts`
2. Modify the file
3. `:e anotherfile`
4. `:wqa`

On `main`:

https://user-images.githubusercontent.com/889383/200172949-8c708c59-a6d5-4d23-b67b-ebafab215d3b.mp4

The `file.ts` file is not saved in the end. I don't show it on video, but I open `file.ts` again on the next video and file is not there.

On this branch, with my fixes:


https://user-images.githubusercontent.com/889383/200173016-d7d44ba6-5174-4974-a83d-7ed4c805c67a.mp4

The `file.ts` was saved correctly this time and it was formatted with `prettierd` (the trailing empty lines are gone). Neovim did not crash. This is the expected behavior.