### PR TITLE
Prevent overlapping windows when border is set

### DIFF
--- a/lua/fidget.lua
+++ b/lua/fidget.lua
@@ -295,7 +295,11 @@ function base_fidget:show(offset)
     api.nvim_buf_add_highlight(self.bufid, -1, "FidgetTitle", 0, 0, -1)
   end
 
-  return #self.lines + offset
+  local next_offset = #self.lines + offset
+  if options.window.border ~= "none" then
+    next_offset = next_offset + 2
+  end
+  return next_offset
 end
 
 function base_fidget:kill_task(task)


### PR DESCRIPTION
# Before:
![image](https://user-images.githubusercontent.com/8677866/212552064-9fb3d113-9c43-4f22-a31b-c2f107655b4c.png)

# After:
![image](https://user-images.githubusercontent.com/8677866/212552016-60846516-46cc-4da6-96bf-03e0cd435cf8.png)

