### PR TITLE
Fix log file path in documentation

### DIFF
--- a/doc/fidget.md
+++ b/doc/fidget.md
@@ -261,7 +261,7 @@ Type: `bool` (default: `false`)
 #### debug.logging
 
 Whether to enable logging, for debugging. The log is written to
-`~/.local/share/fidget.nvim.log`.
+`~/.local/share/nvim/fidget.nvim.log`.
 
 Type: `bool` (default: `false`)
 

--- a/doc/fidget.txt
+++ b/doc/fidget.txt
@@ -328,7 +328,7 @@ Type: `bool` (default: `false`)
 
 debug.logging                          Whether to enable logging, for
                                        debugging. The log is written to
-                                       `~/.local/share/fidget.nvim.log`.
+                                       `~/.local/share/nvim/fidget.nvim.log`.
 
 
 Type: `bool` (default: `false`)


### PR DESCRIPTION
This is just a minor thing I noticed, when I set the option `debug.logging` to **true** in the setup function, the actual file where the log was being written to was `~/.local/share/nvim/fidget.nvim.log`, and not `~/.local/share/fidget.nvim.log`, as stated in the docs.

I did a quick peek at the code, and apparently this path is being decided by the `stdpath('data')` function, which on both neovim 0.7.0 and 0.8.2 returns `~/.local/share/nvim`.

I tried on these versions because they are the minimum required version mentioned in the readme (0.7.0) and the one that I use (0.8.2).

I don't know if it was okay to just create a PR or if I should have an issue, sorry if it was a bit intrusive!

And of course, many thanks for your work, such a nice plugin! :blush: