### PR TITLE
feat(options): added `max_messages` option

### DIFF
--- a/doc/fidget.md
+++ b/doc/fidget.md
@@ -89,6 +89,7 @@ The following table shows the default options for this plugin:
     border = "none",          -- style of border for the fidget window
   },
   fmt = {
+    max_messages = 2,         -- The maximum number of messages stacked at any give time
     leftpad = true,           -- right-justify text in fidget box
     stack_upwards = true,     -- list of tasks grows upwards
     max_width = 0,            -- maximum width of the fidget box
@@ -207,6 +208,14 @@ clear each task as soon as it is completed; set to any negative number to keep
 it around until its fidget is cleared.
 
 Type: `number` (default: `1000`)
+
+#### fmt.max_messages
+
+The maximum number of messages you want stacked at any given time.  
+Set this to a higher number if you want to display more messages, for chatty lsp
+servers this might cover up a large area of the window.
+
+Type: `number` (default: `2`)
 
 #### fmt.leftpad
 

--- a/doc/fidget.txt
+++ b/doc/fidget.txt
@@ -101,6 +101,7 @@ The following table shows the default options for this plugin:
         border = "none",          -- style of border for the fidget window
       },
       fmt = {
+        max_messages = 2,         -- The maximum number of messages stacked at any give time
         leftpad = true,           -- right-justify text in fidget box
         stack_upwards = true,     -- list of tasks grows upwards
         max_width = 0,            -- maximum width of the fidget box
@@ -233,6 +234,14 @@ it around until its fidget is cleared.
 
 Type: `number` (default: `1000`)
 
+
+FMT.MAX_MESSAGES
+
+The maximum number of messages you want stacked at any given time.  
+Set this to a higher number if you want to display more messages, for chatty lsp
+servers this might cover up a large area of the window.
+
+Type: `number` (default: `2`)
 
 FMT.LEFTPAD
 

--- a/lua/fidget.lua
+++ b/lua/fidget.lua
@@ -46,6 +46,7 @@ local options = {
     task_decay = 1000,
   },
   fmt = {
+    max_messages = 2,
     leftpad = true,
     stack_upwards = true,
     max_width = 0,
@@ -189,11 +190,11 @@ function base_fidget:fmt()
         subtab(task.message),
         task.percentage
       )
-    if line then
+    if line and #self.lines < options.fmt.max_messages then
       if options.fmt.stack_upwards then
-        table.insert(self.lines, 1, line)
+          table.insert(self.lines, 1, line)
       else
-        table.insert(self.lines, line)
+          table.insert(self.lines, line)
       end
       self.max_line_len = math.max(self.max_line_len, strlen(line))
     end


### PR DESCRIPTION
# Description
Some LSP server are very chatty, and when they send too many messages in a short burst the area taken by fidget.nvim becomes so large that it covers up some of the editing window area.

The new option (defaulted to `2`) limits the number of messages shown at any given time.

**Current behavior**
![CleanShot 2023-05-04 at 19 57 41](https://user-images.githubusercontent.com/145502/236451574-23ca0ea9-8dea-459f-8808-0cb678bc87b3.gif)

**New behavior**
![CleanShot 2023-05-04 at 19 59 30](https://user-images.githubusercontent.com/145502/236451641-c1115d9b-eac8-4d04-ab69-67fb469bf3ea.gif)



Fixes #122