### PR TITLE
Fix error when command-line window is open

### DIFF
--- a/lua/fidget.lua
+++ b/lua/fidget.lua
@@ -327,7 +327,8 @@ function base_fidget:close()
     -- Deleting the buffer at this point causes a Neovim crash.
     -- We let the buffer be - it will be deleted automatically on vim exit.
     if self.bufid ~= api.nvim_get_current_buf() then
-      api.nvim_buf_delete(self.bufid, { force = true })
+      -- wrap nvim_buf_delete to ignore E11 (#136)
+      pcall(api.nvim_buf_delete, self.bufid, { force = true })
     end
     self.bufid = nil
   end


### PR DESCRIPTION
quick hack, there's probably a better solution then to just ignore the error.

edit: fixes #136 