### PR TITLE
feat!: add stack upwards option

### DIFF
--- a/doc/fidget.md
+++ b/doc/fidget.md
@@ -67,6 +67,7 @@ The following table shows the default options for this plugin:
 
     -- Options related to how notifications are rendered as text
     view = {
+      stack_upwards = true,       -- Display notification items from bottom to top
       icon_separator = " ",       -- Separator between group name and icon
       group_separator = "---",    -- Separator between notification groups
       group_separator_hl =        -- Highlight group used for group separator
@@ -326,6 +327,14 @@ fidget.notification.default_config = {
   error_annote = "ERROR",
 }
 ```
+
+notification.view.stack_upwards
+: Display notification items from bottom to top
+
+Setting this to true tends to lead to more stable animations when the
+window is bottom-aligned.
+
+Type: `boolean` (default: `true`)
 
 notification.view.icon_separator
 : Separator between group name and icon

--- a/lua/fidget/notification.lua
+++ b/lua/fidget/notification.lua
@@ -33,9 +33,12 @@ local logger     = require("fidget.logger")
 ---@alias NotificationDisplay string | fun(now: number, items: NotificationItem[]): string
 
 --- Used to configure the behavior of notification groups.
+---
+--- If both name and icon are nil, then no group header is rendered.
+---
 ---@class NotificationConfig
----@field name              NotificationDisplay?  name of the group; if nil, tostring(key) is used as name
----@field icon              NotificationDisplay?  icon of the group; if nil, no icon is used
+---@field name              NotificationDisplay?  name of the group
+---@field icon              NotificationDisplay?  icon of the group
 ---@field icon_on_left      boolean?  if true, icon is rendered on the left instead of right
 ---@field annote_separator  string?   separator between message from annote; defaults to " "
 ---@field ttl               number?   how long a notification item should exist; defaults to 3

--- a/lua/fidget/notification/view.lua
+++ b/lua/fidget/notification/view.lua
@@ -20,6 +20,14 @@ local M = {}
 
 --- Options related to how notifications are rendered as text
 require("fidget.options").declare(M, "notification.view", {
+  --- Display notification items from bottom to top
+  ---
+  --- Setting this to true tends to lead to more stable animations when the
+  --- window is bottom-aligned.
+  ---
+  ---@type boolean
+  stack_upwards = true,
+
   --- Separator between group name and icon
   ---
   --- Must not contain any newlines. Set to `""` to remove the gap between names
@@ -39,11 +47,6 @@ require("fidget.options").declare(M, "notification.view", {
   ---
   ---@type string?
   group_separator_hl = "Comment",
-
-  --- Display notification items from bottom to top
-  ---
-  ---@type boolean
-  stack_upwards = true,
 })
 
 


### PR DESCRIPTION
general idea: instead of having a `lines` and `highlights` arrays that we append to, we create an array of "rendered items" which then get converted into the `lines` and `highlights` arrays with correct ordering.

A `render_item` just contains the lines and `render_item` relative highlights.

Not sure about: https://github.com/0xAdk/fidget.nvim/blob/12f4be2e4f2e887b4aeec97b0d392fdd2c4794d6/lua/fidget/notification/view.lua#L144-L152
I went from `string.gmatch` to `vim.gsplit` since it's cleaner and in testing found gmatch implicitly converts from numbers to strings, so I added it explicitly.

Set stack_upwards to `true` by default since that was how legacy worked.

closes #152