### PR TITLE
feat!: option to position window away from cursor

### DIFF
--- a/doc/fidget.md
+++ b/doc/fidget.md
@@ -93,6 +93,7 @@ The following table shows the default options for this plugin:
       y_padding = 0,              -- Padding from bottom edge of window boundary
       align_bottom = true,        -- Whether to bottom-align the notification window
       relative = "editor",        -- What the notification window position is relative to
+      dynamic_positioning = false,-- Align the window depending on the cursor position
     },
   },
 

--- a/doc/fidget.md
+++ b/doc/fidget.md
@@ -93,7 +93,7 @@ The following table shows the default options for this plugin:
       y_padding = 0,              -- Padding from bottom edge of window boundary
       align_bottom = true,        -- Whether to bottom-align the notification window
       relative = "editor",        -- What the notification window position is relative to
-      dynamic_positioning = false,-- Align the window depending on the cursor position
+      dynamic_positioning = false,-- Align the window depending on the cursor position (overrides align_bottom)
     },
   },
 

--- a/doc/fidget.md
+++ b/doc/fidget.md
@@ -91,9 +91,8 @@ The following table shows the default options for this plugin:
       max_height = 0,             -- Maximum height of the notification window
       x_padding = 1,              -- Padding from right edge of window boundary
       y_padding = 0,              -- Padding from bottom edge of window boundary
-      align_bottom = true,        -- Whether to bottom-align the notification window
+      align = "bottom",           -- How to align the notification window
       relative = "editor",        -- What the notification window position is relative to
-      dynamic_positioning = false,-- Align the window depending on the cursor position (overrides align_bottom)
     },
   },
 
@@ -493,10 +492,10 @@ notification.window.y_padding
 
 Type: `integer` (default: `0`)
 
-notification.window.align_bottom
-: Whether to bottom-align the notification window
+notification.window.align
+: How to align the notification window
 
-Type: `boolean` (default: `true`)
+Type: `"top"|"bottom"|"avoid_cursor"` (default: `"bottom"`)
 
 notification.window.relative
 : What the notification window position is relative to

--- a/doc/fidget.txt
+++ b/doc/fidget.txt
@@ -103,9 +103,8 @@ The following table shows the default options for this plugin:
           max_height = 0,             -- Maximum height of the notification window
           x_padding = 1,              -- Padding from right edge of window boundary
           y_padding = 0,              -- Padding from bottom edge of window boundary
-          align_bottom = true,        -- Whether to bottom-align the notification window
+	  align = "bottom",           -- How to align the notification window
           relative = "editor",        -- What the notification window position is relative to
-          dynamic_positioning = false,-- Align the window depending on the cursor position (overrides align_bottom)
         },
       },
     
@@ -690,14 +689,14 @@ notification.window.y_padding          Padding from bottom edge of window bounda
 Type: `integer` (default: `0`)
 
 
-                                   *fidget-notification.window.align_bottom*
+                                      *fidget-notification.window.align*
 
 
-notification.window.align_bottom       Whether to bottom-align the notification window
+notification.window.align              How to align the notification window
 
 
 
-Type: `boolean` (default: `true`)
+Type: `"top"|"bottom"|"avoid_cursor"` (default: `"bottom"`)
 
 
                                        *fidget-notification.window.relative*

--- a/doc/fidget.txt
+++ b/doc/fidget.txt
@@ -105,6 +105,7 @@ The following table shows the default options for this plugin:
           y_padding = 0,              -- Padding from bottom edge of window boundary
           align_bottom = true,        -- Whether to bottom-align the notification window
           relative = "editor",        -- What the notification window position is relative to
+          dynamic_positioning = false,-- Align the window depending on the cursor position
         },
       },
     

--- a/doc/fidget.txt
+++ b/doc/fidget.txt
@@ -105,7 +105,7 @@ The following table shows the default options for this plugin:
           y_padding = 0,              -- Padding from bottom edge of window boundary
           align_bottom = true,        -- Whether to bottom-align the notification window
           relative = "editor",        -- What the notification window position is relative to
-          dynamic_positioning = false,-- Align the window depending on the cursor position
+          dynamic_positioning = false,-- Align the window depending on the cursor position (overrides align_bottom)
         },
       },
     

--- a/lua/fidget/notification/window.lua
+++ b/lua/fidget/notification/window.lua
@@ -207,6 +207,7 @@ end
 ---@return number       col
 ---@return ("NE"|"SE")  anchor
 function M.get_window_position()
+  local align_bottom
   local col, row, row_max
   local first_line = vim.fn.line("w0")
   local current_line = vim.api.nvim_win_get_cursor(0)[1]
@@ -223,8 +224,9 @@ function M.get_window_position()
     col, row_max = M.get_editor_dimensions()
     local window_pos = vim.api.nvim_win_get_position(0)
     local cursor_pos = window_pos[1] + (current_line - first_line)
+    align_bottom = should_align_bottom(cursor_pos, row_max)
 
-    if should_align_bottom(cursor_pos, row_max) then
+    if align_bottom then
       row = row_max
     else
       -- When the layout is anchored at the top, need to check &tabline height
@@ -241,20 +243,20 @@ function M.get_window_position()
       -- When winbar is set, effective win height is reduced by 1 (see :help winbar)
       row_max = row_max - 1
     end
-
     local align_bottom = should_align_bottom(cursor_pos, row_max)
+
     row = align_bottom and row_max or 1
   end
 
   col = math.max(0, col - M.options.x_padding - state.x_offset)
 
-  if M.options.align_bottom then
+  if align_bottom then
     row = math.max(0, row - M.options.y_padding)
   else
     row = math.min(row_max, row + M.options.y_padding)
   end
 
-  return row, col, (M.options.align_bottom and "S" or "N") .. "E"
+  return row, col, (align_bottom and "S" or "N") .. "E"
 end
 
 --- Set local options on a window.

--- a/lua/fidget/notification/window.lua
+++ b/lua/fidget/notification/window.lua
@@ -207,8 +207,7 @@ end
 ---@return number       col
 ---@return ("NE"|"SE")  anchor
 function M.get_window_position()
-  local align_bottom
-  local col, row, row_max
+  local align_bottom, col, row, row_max
   local first_line = vim.fn.line("w0")
   local current_line = vim.api.nvim_win_get_cursor(0)[1]
 

--- a/lua/fidget/notification/window.lua
+++ b/lua/fidget/notification/window.lua
@@ -83,10 +83,10 @@ require("fidget.options").declare(M, "notification.window", {
   ---@type integer
   y_padding = 0,
 
-  --- Whether to bottom-align the notification window
+  --- How to align the notification window
   ---
-  ---@type boolean
-  align_bottom = true,
+  ---@type "top" | "bottom" | "avoid_cursor"
+  align = "bottom",
 
   --- What the notification window position is relative to
   ---
@@ -94,12 +94,6 @@ require("fidget.options").declare(M, "notification.window", {
   ---
   ---@type "editor" | "win"
   relative = "editor",
-
-  --- Aligns the window at the top or bottom depending on the cursor position
-  ---
-  --- Overrites `align_bottom` if true
-  ---@type boolean
-  dynamic_positioning = false,
 })
 
 --- Local state maintained by this module.
@@ -212,10 +206,12 @@ function M.get_window_position()
   local current_line = vim.api.nvim_win_get_cursor(0)[1]
 
   local function should_align_bottom(cursor_pos, rows)
-    if M.options.dynamic_positioning then
-      return cursor_pos <= (rows / 2)
+    if M.options.align == "top" then
+      return false
+    elseif M.options.align == "bottom" then
+      return true
     else
-      return M.options.align_bottom
+      return cursor_pos <= (rows / 2)
     end
   end
 
@@ -242,7 +238,7 @@ function M.get_window_position()
       -- When winbar is set, effective win height is reduced by 1 (see :help winbar)
       row_max = row_max - 1
     end
-    local align_bottom = should_align_bottom(cursor_pos, row_max)
+    align_bottom = should_align_bottom(cursor_pos, row_max)
 
     row = align_bottom and row_max or 1
   end


### PR DESCRIPTION
This adds the `window.dynamic_positioning` option, which will essentially set the value of `align_bottom` depending on which half of the screen the cursor is currently in.

https://github.com/j-hui/fidget.nvim/assets/47333659/811d409d-eb79-434c-9f65-daf42dc97cb8

