### PR TITLE
fix: checking for winid value before to evoke it

### DIFF
--- a/lua/fidget/integration/nvim-tree.lua
+++ b/lua/fidget/integration/nvim-tree.lua
@@ -22,7 +22,10 @@ require("fidget.options").declare(M, "integration.nvim-tree", M.options, functio
   end
 
   local ok, api = pcall(function() return require("nvim-tree.api") end)
-  if not ok then
+  if not ok or not api.tree.winid then
+    -- NOTE: api.tree.winid doesn't exist on some older versions of nvim-tree.
+    -- We need it to figure out the size of the nvim-tree window, so if it does
+    -- not exist, there's no point in installing any nvim-tree event callbacks.
     return
   end
 
@@ -32,18 +35,11 @@ require("fidget.options").declare(M, "integration.nvim-tree", M.options, functio
 
   local function resize()
     if win.options.relative == "editor" then
-      -- Winid can be nil
-      local winid_fn = api.tree.winid
-
-      -- Check if winid_function is not nil before calling it
-      if winid_fn then
-        local winid = winid_fn()
-        local col = vim.api.nvim_win_get_position(winid)[2]
-
-        if col > 1 then
-          local width = vim.api.nvim_win_get_width(winid)
-          win.set_x_offset(width)
-        end
+      local winid = api.tree.winid()
+      local col = vim.api.nvim_win_get_position(winid)[2]
+      if col > 1 then
+        local width = vim.api.nvim_win_get_width(winid)
+        win.set_x_offset(width)
       end
     end
   end

--- a/lua/fidget/integration/nvim-tree.lua
+++ b/lua/fidget/integration/nvim-tree.lua
@@ -32,11 +32,18 @@ require("fidget.options").declare(M, "integration.nvim-tree", M.options, functio
 
   local function resize()
     if win.options.relative == "editor" then
-      local winid = api.tree.winid()
-      local col = vim.api.nvim_win_get_position(winid)[2]
-      if col > 1 then
-        local width = vim.api.nvim_win_get_width(winid)
-        win.set_x_offset(width)
+      -- Winid can be nil
+      local winid_fn = api.tree.winid
+
+      -- Check if winid_function is not nil before calling it
+      if winid_fn then
+        local winid = winid_fn()
+        local col = vim.api.nvim_win_get_position(winid)[2]
+
+        if col > 1 then
+          local width = vim.api.nvim_win_get_width(winid)
+          win.set_x_offset(width)
+        end
       end
     end
   end


### PR DESCRIPTION
To handle the error below:
![240119_11h40m13s_screenshot](https://github.com/j-hui/fidget.nvim/assets/40039337/f281a236-59ae-4bd4-82aa-219bbafe9255)

I noticed in the original code that the `winid` property was invoked (with `()`) even when it was `nil`. 
The refined code incorporates a validation step to ensure that the function is called exclusively when a valid value is present.