### PR TITLE
fix: missing argument for nvim_tabpage_list_wins

### DIFF
--- a/lua/fidget/notification/window.lua
+++ b/lua/fidget/notification/window.lua
@@ -190,7 +190,7 @@ function M.get_editor_dimensions()
   local statusline_height = 0
   local laststatus = vim.opt.laststatus:get()
   if laststatus == 2 or laststatus == 3
-      or (laststatus == 1 and #vim.api.nvim_tabpage_list_wins() > 1)
+      or (laststatus == 1 and #vim.api.nvim_tabpage_list_wins(0) > 1)
   then
     statusline_height = 1
   end


### PR DESCRIPTION
Hey there!

This is fixing the following plugin crash which occurs for me after opening then closing window splits. Function `nvim_tabpage_list_wins` looks to require at least one argument

```
Error executing vim.schedule lua callback: .../fidget.nvim/lua/fidget/poll.lua:119: .../fidg
et.nvim/lua/fidget/notification/window.lua:182: .../fidget.nvim/lua/fidget/notification/window.lua:193: Expected 1 a
rgument
stack traceback:
        [C]: in function 'error'
        .../fidget.nvim/lua/fidget/poll.lua:119: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```
