### PR TITLE
feat: show progress for clients before they initialize

### DIFF
--- a/lua/fidget/progress/lsp.lua
+++ b/lua/fidget/progress/lsp.lua
@@ -82,6 +82,14 @@ require("fidget.options").declare(M, "progress.lsp", M.options, function()
   end
 end)
 
+function M.get_clients(client_ids)
+  local clients = {}
+  for _, client_id in pairs(client_ids) do
+    table.insert(clients, vim.lsp.get_client_by_id(client_id))
+  end
+  return clients
+end
+
 --- Consumes LSP progress messages from each client.progress ring buffer.
 ---
 --- Based on vim.lsp.status(), except this implementation does not format the
@@ -89,8 +97,8 @@ end)
 ---
 ---@return ProgressMessage[] progress_messages
 ---@see fidget.progress.lsp.ProgressMessage
-function M.poll_for_messages()
-  local clients = vim.lsp.get_clients()
+function M.poll_for_messages(client_ids)
+  local clients = M.get_clients(client_ids)
   if #clients == 0 then
     -- Issue being tracked in #177
     logger.warn("No active LSP clients to poll from (see issue #177)")
@@ -178,8 +186,8 @@ if not vim.lsp.status then
   ---
   ---@protected
   ---@return ProgressMessage[] progress_messages
-  function M.poll_for_messages()
-    local clients = vim.lsp.get_active_clients()
+  function M.poll_for_messages(client_ids)
+    local clients = M.get_clients(client_ids)
     if #clients == 0 then
       -- Issue being tracked in #177
       logger.warn("No active LSP clients to poll from (see issue #177)")


### PR DESCRIPTION
This change updates the lsp progress implementation to keep track of known client ids (by monitoring the `LspProgress` event). Later when getting a list of clients we can then use this list instead of calling `vim.lsp.get_clients` which only returns active clients.

This allows showing progress notifications for clients before they have completed initializing.

Closes #177 