### PR TITLE
doc: fix typo in notification documentation

### DIFF
--- a/lua/fidget/notification.lua
+++ b/lua/fidget/notification.lua
@@ -9,7 +9,7 @@ local logger                = require("fidget.logger")
 --- Used to determine the identity of notification items and groups.
 ---@alias Key any
 
---- Second (level) paramter passed to |fidget.notification.notify|.
+--- Second (level) parameter passed to |fidget.notification.notify|.
 ---
 --- `string` indicates highlight group name; otherwise, `number` indicates
 --- the |vim.log.levels| value (that will resolve to a highlight group as


### PR DESCRIPTION
Just stumbled upon this while reading the docs. It's not much but it's honest work.

I assembled the commit name from other commits. Let me know if something should be changed.