### PR TITLE
chore(doc): fix minor syntax error in progress.handle.create example code

### DIFF
--- a/doc/fidget-api.txt
+++ b/doc/fidget-api.txt
@@ -428,7 +428,7 @@ handle.create({message})                         *fidget.progress.handle.create*
      -- Or you can use the `report` method to bulk-update
      -- properties.
      handle:report({
-       title = "The task status changed"
+       title = "The task status changed",
        message = "Doing another thing...",
        percentage = 50,
      })


### PR DESCRIPTION
I was playing around with the api's and noticed a missing comma in the documentation example code. Thanks for all the hard work on this plugin.