### PR TITLE
fix: call strdisplaywidth() within the context of the fidget buffer

### DIFF
--- a/lua/fidget/notification.lua
+++ b/lua/fidget/notification.lua
@@ -371,8 +371,8 @@ notification.poller = poll.Poller {
       end
 
       notification.window.guard(function()
-        notification.window.set_lines(v.lines, v.highlights, v.width)
-        notification.window.show(v.width, #v.lines)
+        local width = notification.window.set_lines(v.lines, v.highlights, true)
+        notification.window.show(width, #v.lines)
       end)
       return true
     else

--- a/lua/fidget/notification/view.lua
+++ b/lua/fidget/notification/view.lua
@@ -4,7 +4,6 @@
 local M = {}
 
 ---@class NotificationView
----@field width       number                    the maximum width of any line
 ---@field lines       string[]                  text to show in the notification
 ---@field highlights  NotificationHighlight[]   buf_add_highlight() params, applied in order
 
@@ -272,7 +271,7 @@ function M.render(now, groups)
     end
   end
 
-  local width, lines, highlights = 0, {}, {}
+  local lines, highlights = {}, {}
 
   local start, stop, step
   if M.options.stack_upwards then
@@ -284,7 +283,6 @@ function M.render(now, groups)
   for i = start, stop, step do
     local item, offset = render_items[i], #lines
     for _, line in ipairs(item.lines) do
-      width = math.max(width, vim.fn.strdisplaywidth(line))
       table.insert(lines, line)
     end
     for _, highlight in ipairs(item.highlights) do
@@ -294,7 +292,6 @@ function M.render(now, groups)
   end
 
   return {
-    width = width,
     lines = lines,
     highlights = highlights,
   }

--- a/lua/fidget/notification/window.lua
+++ b/lua/fidget/notification/window.lua
@@ -424,24 +424,32 @@ end
 --- Replace the set of lines in the Fidget window, right-justify them, and apply
 --- highlights.
 ---
---- To forego right-justification, pass nil for right_col.
----
 ---@param lines       string[]                  lines to place into buffer
 ---@param highlights  NotificationHighlight[]   list of highlights to apply
----@param right_col   number|nil                optional display width, to right-justify
-function M.set_lines(lines, highlights, right_col)
+---@param right_align boolean                   whether to right-justify the text
+---@return integer max_width
+function M.set_lines(lines, highlights, right_align)
   local buffer_id = M.get_buffer()
   local namespace_id = M.get_namespace()
 
   -- Clear previous highlights
   vim.api.nvim_buf_clear_namespace(buffer_id, namespace_id, 0, -1)
 
-  if right_col then
+  local line_widths = {}
+  local max_width = 0
+  vim.api.nvim_buf_call(buffer_id, function()
+    for l, line in ipairs(lines) do
+      line_widths[l] = vim.fn.strdisplaywidth(line)
+      max_width = math.max(max_width, line_widths[l])
+    end
+  end)
+
+  if right_align then
     local offsets = {}
 
     -- Right justify each line by padding spaces
-    for l, line in ipairs(lines) do
-      local offset = right_col - vim.fn.strdisplaywidth(line)
+    for l, width in ipairs(line_widths) do
+      local offset = max_width - width
       lines[l] = string.rep(" ", offset) .. lines[l]
       offsets[l] = offset
     end
@@ -473,6 +481,8 @@ function M.set_lines(lines, highlights, right_col)
         highlight.col_end)
     end
   end
+
+  return max_width
 end
 
 --- Close the Fidget window and associated buffers.


### PR DESCRIPTION
The return value of `strdisplaywidth()` depends on the local options such as `wrap`, and seems to change wildly if the cursor is positioned inside a window opened by `lsp.util.open_floating_preview()`:

<img width="977" height="305" alt="image" src="https://github.com/user-attachments/assets/3b23a139-141b-49ce-ab27-bc0261d7cf3c" />

My PR fixes this bug by switching to fidget's buffer with `nvim_buf_call()`.