### PR TITLE
Fix "Invalid 'virt_text_pos': 'eol_right_align' error

### DIFF
--- a/lua/fidget/notification/window.lua
+++ b/lua/fidget/notification/window.lua
@@ -460,7 +460,7 @@ function M.set_lines(lines, width)
   for _, line in ipairs(lines) do
     vim.api.nvim_buf_set_lines(buffer_id, -1, -1, false, { "" })
     local last = vim.api.nvim_buf_line_count(buffer_id) - 1
-    if vim.fn.has("nvim-0.11.0") then
+    if vim.fn.has("nvim-0.11.0") == 1 then
       vim.api.nvim_buf_set_extmark(buffer_id, namespace_id, last, 0, {
         virt_text = line,
         virt_text_pos = "eol_right_align",


### PR DESCRIPTION
<img width="1919" height="159" alt="2025-08-02_08-53" src="https://github.com/user-attachments/assets/f7f5eef8-089d-4dd4-a130-cb28a3328d6a" />

Fix the error above by checking neovim version 0.11.0 explicitly by comparing the return value to 1, since 0 is truthy in lua [credits to [liskin](https://github.com/liskin)](https://github.com/j-hui/fidget.nvim/issues/285)