### PR TITLE
feat!: make setup optional

### DIFF
--- a/plugin/fidget.lua
+++ b/plugin/fidget.lua
@@ -1,0 +1,1 @@
+require("fidget").setup({})


### PR DESCRIPTION
Problem:

The user is required to call `setup()` even if they are perfectly happy with the default options

Solution:

Make setup optional

## Context:

Neovim has recently added some documentation of developing a lua plugin with some "best practices" https://github.com/neovim/neovim/blob/master/runtime/doc/lua-plugin.txt

In the `Initialization` section, it is recommended to allow users to opt out of calling setup if the default options are working perfectly fine. For me they are working perfectly fine, and I agree that calling setup is unnecessary in this case.