### PR TITLE
fix: Use only the first line for the telescope picker entry

### DIFF
--- a/lua/telescope/_extensions/fidget.lua
+++ b/lua/telescope/_extensions/fidget.lua
@@ -31,7 +31,7 @@ local format_entry = function(entry)
     table.insert(chunks, { " ", "MsgArea" })
   end
 
-  table.insert(chunks, { entry.message, "MsgArea" })
+  table.insert(chunks, { entry.message:match("([^\n]*)"), "MsgArea" })
 
   return chunks
 end


### PR DESCRIPTION
While using the fidget telescope extension, I noticed that the following error occasionally occurs.

```
vim.schedule callback: .../nvim-data/lazy/telescope.nvim/lua/telescope/pickers.lua:1469: Cursor position outside buffer
stack traceback:
        [C]: in function 'nvim_win_set_cursor'
        .../nvim-data/lazy/telescope.nvim/lua/telescope/pickers.lua:1469: in function 'fn'
        vim/_editor.lua:296: in function <vim/_editor.lua:295>
```

This error seems to occur when the telescope picker entry contains line breaks. I fixed this by using only the first line of entry.message.