### PR TITLE
fix(progress): treat vim.NIL as nil in LSP progress fields

### DIFF
--- a/lua/fidget/progress/lsp.lua
+++ b/lua/fidget/progress/lsp.lua
@@ -115,9 +115,9 @@ function M.poll_for_messages()
       if type(value) == 'table' and value.kind then
         local message = {
           token = progress.token,
-          title = value.title,
-          message = value.message,
-          percentage = value.done and nil or value.percentage,
+          title = value.title ~= vim.NIL and value.title or nil,
+          message = value.message ~= vim.NIL and value.message or nil,
+          percentage = value.done and nil or (value.percentage ~= vim.NIL and value.percentage or nil),
           done = value.kind == "end",
           cancellable = value.cancellable or false,
           lsp_client = client,


### PR DESCRIPTION
Some LSP servers emit `$/progress` notifications whose optional `value.title`, `value.message`, or `value.percentage` fields arrive as JSON `null`, which `vim.lsp` decodes as `vim.NIL`. `vim.NIL` is truthy in Lua but isn't a string/number, so passing it through `M.poll_for_messages()` unchanged crashes downstream display code on string concat / formatting.

This coerces `vim.NIL` → `nil` for those three fields before constructing the `message` table. Non-nil, non-`vim.NIL` values pass through unchanged.

Minimal change, scoped to `lua/fidget/progress/lsp.lua`. I've been running this locally for a while without regressions against servers that don't send `null` (they hit the `~= vim.NIL` short-circuit untouched).