### PR TITLE
fix(health): don't warn about implicit integration when filetype is avoided

### DIFF
--- a/lua/fidget/health.lua
+++ b/lua/fidget/health.lua
@@ -43,8 +43,16 @@ end
 local function check_integrations()
   vim.health.start("fidget.integration")
 
+  -- The recommended migration away from the implicit integrations is to add the
+  -- integration's filetype to 'notification.window.avoid'. Once that is done,
+  -- the integration is effectively superseded, so don't warn about it anymore.
+  local avoid = require("fidget.notification.window").options.avoid
+  local function avoided(ft)
+    return vim.tbl_contains(avoid, ft)
+  end
+
   local xcodebuild = require("fidget.integration.xcodebuild-nvim")
-  if not xcodebuild.explicitly_configured() and xcodebuild.plugin_present() then
+  if not xcodebuild.explicitly_configured() and xcodebuild.plugin_present() and not avoided(xcodebuild.filetype) then
     vim.health.warn("xcodebuild.nvim integration is implicitly enabled", {
       "This automatic integration will be removed in a future release.",
       "Add 'TestExplorer' to the 'notification.window.avoid' list to ensure Fidget continues to avoid xcodebuild.nvim's explorer window.",
@@ -52,7 +60,7 @@ local function check_integrations()
   end
 
   local nvim_tree = require("fidget.integration.nvim-tree")
-  if not nvim_tree.explicitly_configured() and nvim_tree.plugin_present() then
+  if not nvim_tree.explicitly_configured() and nvim_tree.plugin_present() and not avoided(nvim_tree.filetype) then
     vim.health.warn("nvim-tree.lua integration is implicitly enabled", {
       "This automatic integration will be removed in a future release.",
       "Add 'NvimTree' to the 'notification.window.avoid' list to ensure Fidget continues to avoid nvim-tree.lua's file explorer.",


### PR DESCRIPTION
## Problem

The `nvim-tree`/`xcodebuild` integrations are deprecated. Their healthchecks advise migrating by adding the integration's filetype to `notification.window.avoid`:

> This automatic integration will be removed in a future release.
> Add 'NvimTree' to the 'notification.window.avoid' list to ensure Fidget continues to avoid nvim-tree.lua's file explorer.

But `check_integrations()` gates the "implicitly enabled" warning solely on `explicitly_configured()`, which only returns `true` when the **also-deprecated** `integration.<plugin>.enable` option is set.

Result: there is no warning-free configuration for a user of these plugins.

- Follow the advice (`notification.window.avoid = { "NvimTree" }`, leave `enable` unset) → `explicitly_configured()` stays `false` → **"implicitly enabled" warning still fires.**
- Set `integration.nvim-tree.enable = false` to silence it → **"Deprecated setup option" warning fires instead.**

## Fix

Skip the implicit-enabled warning once the integration's filetype is already in `notification.window.avoid`. That makes the documented migration path actually clear the warning.

## Testing

With `nvim-tree` installed and `notification.window.avoid = { "NvimTree" }`:

- Before: `:checkhealth fidget` → `⚠️ WARNING nvim-tree.lua integration is implicitly enabled`
- After: `:checkhealth fidget` → clean ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)